### PR TITLE
Update current

### DIFF
--- a/metrics/current
+++ b/metrics/current
@@ -59,7 +59,7 @@ cases_count{country="BA", region="FBiH", city="Mostar"} 6
 recovered_count{country="BA", region="FBiH", city="Mostar"} 0
 deaths_count{country="BA", region="FBiH", city="Mostar"} 0
 # FBiH Konjic
-cases_count{country="BA", region="FBiH", city="Konjic"} 4
+cases_count{country="BA", region="FBiH", city="Konjic"} 9
 recovered_count{country="BA", region="FBiH", city="Konjic"} 0
 deaths_count{country="BA", region="FBiH", city="Konjic"} 0
 # FBiH Gorazde


### PR DESCRIPTION
https://www.klix.ba/vijesti/bih/u-konjicu-pet-novih-slucajeva-zaraze-koronavirusom-ukupno-69-u-bih/200320031 