### PR TITLE
Update current

### DIFF
--- a/metrics/current
+++ b/metrics/current
@@ -1,7 +1,7 @@
 # RS Unknown
 cases_count{country="BA", region="RS", city="Unknown"} 0
 recovered_count{country="BA", region="RS", city="Unknown"} 2
-deaths_count{country="BA", region="RS", city="Unknown"} 0
+deaths_count{country="BA", region="RS", city="Unknown"} 1
 # RS Banja Luka
 cases_count{country="BA", region="RS", city="Banja Luka"} 45
 recovered_count{country="BA", region="RS", city="Banja Luka"} 0


### PR DESCRIPTION
https://www.klix.ba/vijesti/bih/prva-zrtva-koronavirusa-u-bih-u-bihacu-preminula-starija-zena/200321089