### PR TITLE
Update Travnik

### DIFF
--- a/metadata/geo/ba.json
+++ b/metadata/geo/ba.json
@@ -124,5 +124,11 @@
           "latitude": 44.72453,
           "longitude": 17.32431,
           "name": "Celinac"
+        },
+          {
+          "key": "Travnik",
+          "latitude": 44.22637,
+          "longitude": 17.66583,
+          "name": "Travnik"
         }
 ]

--- a/metrics/current
+++ b/metrics/current
@@ -86,3 +86,7 @@ deaths_count{country="BA", region="RS", city="Celinac"} 0
 cases_count{country="BA", region="FBiH", city="Sarajevo"} 3
 recovered_count{country="BA", region="FBiH", city="Sarajevo"} 0
 deaths_count{country="BA", region="FBiH", city="Sarajevo"} 0
+# FBiH Travnik
+cases_count{country="BA", region="FBiH", city="Travnik"} 1
+recovered_count{country="BA", region="FBiH", city="Travnik"} 0
+deaths_count{country="BA", region="FBiH", city="Travnik"} 0


### PR DESCRIPTION
https://www.klix.ba/vijesti/bih/novi-slucaj-koronavirusa-u-travniku-zarazena-osoba-bila-na-proslavi-u-konjicu/200321124