### PR TITLE
new case in konjic

### DIFF
--- a/metrics/current
+++ b/metrics/current
@@ -63,7 +63,7 @@ cases_count{country="BA", region="FBiH", city="Mostar"} 7
 recovered_count{country="BA", region="FBiH", city="Mostar"} 0
 deaths_count{country="BA", region="FBiH", city="Mostar"} 0
 # FBiH Konjic
-cases_count{country="BA", region="FBiH", city="Konjic"} 10
+cases_count{country="BA", region="FBiH", city="Konjic"} 11
 recovered_count{country="BA", region="FBiH", city="Konjic"} 0
 deaths_count{country="BA", region="FBiH", city="Konjic"} 0
 # FBiH Gorazde


### PR DESCRIPTION
https://www.klix.ba/vijesti/bih/u-konjicu-jos-jedna-osoba-zarazena-koronavirusom-u-tom-gradu-ih-je-sada-ukupno-11/200322127