### PR TITLE
Update current

### DIFF
--- a/metrics/current
+++ b/metrics/current
@@ -59,7 +59,7 @@ cases_count{country="BA", region="FBiH", city="Bihac"} 4
 recovered_count{country="BA", region="FBiH", city="Bihac"} 0
 deaths_count{country="BA", region="FBiH", city="Bihac"} 0
 # FBiH Mostar
-cases_count{country="BA", region="FBiH", city="Mostar"} 7
+cases_count{country="BA", region="FBiH", city="Mostar"} 6
 recovered_count{country="BA", region="FBiH", city="Mostar"} 0
 deaths_count{country="BA", region="FBiH", city="Mostar"} 0
 # FBiH Konjic


### PR DESCRIPTION
https://www.oslobodjenje.ba/vijesti/daily-news/covid-19-live-mapa-zarazenih-u-bih-540353