### PR TITLE
Update ba.json

### DIFF
--- a/metadata/geo/ba.json
+++ b/metadata/geo/ba.json
@@ -136,6 +136,12 @@
           "latitude": 44.4685,
           "longitude": 17.3921,
           "name": "Knezevo"
+                  },
+          {
+          "key": "Brcko",
+          "latitude": 44.87278,
+          "longitude": 18.80833,
+          "name": "Brcko"
         },
           {
           "key": "Modrica",


### PR DESCRIPTION
https://www.klix.ba/vijesti/bih/koronavirus-potvrdjen-i-u-brckom-zarazene-dvije-mladje-osobe/200323054