### PR TITLE
Update current

### DIFF
--- a/metrics/current
+++ b/metrics/current
@@ -106,3 +106,7 @@ deaths_count{country="BA", region="RS", city="Modrica"} 0
 cases_count{country="BA", region="Brcko District", city="Brcko"} 2
 recovered_count{country="BA", region="Brcko District", city="Brcko"} 0
 deaths_count{country="BA", region="Brcko District", city="Brcko"} 0
+# FBiH Breza
+cases_count{country="BA", region="FBiH", city="Breza"} 1
+recovered_count{country="BA", region="FBiH", city="Breza"} 0
+deaths_count{country="BA", region="FBiH", city="Breza"} 0


### PR DESCRIPTION
https://www.klix.ba/vijesti/bih/prvi-slucaj-koronavirusa-u-brezi-ukupno-132-u-bih/200323247