### PR TITLE
Update current

### DIFF
--- a/metrics/current
+++ b/metrics/current
@@ -5,7 +5,7 @@ deaths_count{country="BA", region="RS", city="Unknown"} 0
 # FBiH Unknown
 cases_count{country="BA", region="FBiH", city="Unknown"} 0
 recovered_count{country="BA", region="FBiH", city="Unknown"} 0
-deaths_count{country="BA", region="FBiH", city="Unknown"} 1
+deaths_count{country="BA", region="FBiH", city="Unknown"} 2
 # RS Banja Luka
 cases_count{country="BA", region="RS", city="Banja Luka"} 70
 recovered_count{country="BA", region="RS", city="Banja Luka"} 0


### PR DESCRIPTION
https://www.klix.ba/vijesti/bih/preminuo-vozac-direktora-kompanije-igman-koji-je-bio-zarazen-koronavirusom/200324084