### PR TITLE
Update current

### DIFF
--- a/metrics/current
+++ b/metrics/current
@@ -67,7 +67,7 @@ cases_count{country="BA", region="FBiH", city="Visoko"} 1
 recovered_count{country="BA", region="FBiH", city="Visoko"} 0
 deaths_count{country="BA", region="FBiH", city="Visoko"} 0
 # FBiH Mostar
-cases_count{country="BA", region="FBiH", city="Mostar"} 7
+cases_count{country="BA", region="FBiH", city="Mostar"} 9
 recovered_count{country="BA", region="FBiH", city="Mostar"} 0
 deaths_count{country="BA", region="FBiH", city="Mostar"} 0
 # FBiH Konjic
@@ -123,6 +123,6 @@ cases_count{country="BA", region="FBiH", city="Breza"} 1
 recovered_count{country="BA", region="FBiH", city="Breza"} 0
 deaths_count{country="BA", region="FBiH", city="Breza"} 0
 # FBiH Siroki Brijeg
-cases_count{country="BA", region="FBiH", city="Siroki Brijeg"} 3
+cases_count{country="BA", region="FBiH", city="Siroki Brijeg"} 6
 recovered_count{country="BA", region="FBiH", city="Siroki Brijeg"} 0
 deaths_count{country="BA", region="FBiH", city="Siroki Brijeg"} 0


### PR DESCRIPTION
https://www.klix.ba/vijesti/bih/jos-pet-osoba-zarazeno-koronavirusom-ukupno-173-u-bih/200325222