### PR TITLE
Update current

### DIFF
--- a/metrics/current
+++ b/metrics/current
@@ -91,7 +91,7 @@ cases_count{country="BA", region="RS", city="Celinac"} 3
 recovered_count{country="BA", region="RS", city="Celinac"} 0
 deaths_count{country="BA", region="RS", city="Celinac"} 0
 # FBiH Sarajevo
-cases_count{country="BA", region="FBiH", city="Sarajevo"} 5
+cases_count{country="BA", region="FBiH", city="Sarajevo"} 8
 recovered_count{country="BA", region="FBiH", city="Sarajevo"} 0
 deaths_count{country="BA", region="FBiH", city="Sarajevo"} 0
 # FBiH Novi Travnik


### PR DESCRIPTION
https://www.klix.ba/vijesti/bih/jos-tri-osobe-zarazene-koronavirusom-u-sarajevu-ukupno-176-u-bih/200325243?utm_medium=Status&utm_source=Facebook&utm_content=200325243&utm_campaign=Klix.ba+Facebook+status