### PR TITLE
Update current

### DIFF
--- a/metrics/current
+++ b/metrics/current
@@ -91,7 +91,7 @@ cases_count{country="BA", region="RS", city="Celinac"} 3
 recovered_count{country="BA", region="RS", city="Celinac"} 0
 deaths_count{country="BA", region="RS", city="Celinac"} 0
 # FBiH Sarajevo
-cases_count{country="BA", region="FBiH", city="Sarajevo"} 9
+cases_count{country="BA", region="FBiH", city="Sarajevo"} 10
 recovered_count{country="BA", region="FBiH", city="Sarajevo"} 0
 deaths_count{country="BA", region="FBiH", city="Sarajevo"} 0
 # FBiH Novi Travnik


### PR DESCRIPTION
https://www.klix.ba/vijesti/bih/prvi-slucaj-koronavirusa-u-vogosci-ukupno-190-u-bih/200326220, Vogosca added in Sarajevo