### PR TITLE
Grude +1, ukupno 192

### DIFF
--- a/metrics/current
+++ b/metrics/current
@@ -123,8 +123,8 @@ cases_count{country="BA", region="FBiH", city="Breza"} 1
 recovered_count{country="BA", region="FBiH", city="Breza"} 0
 deaths_count{country="BA", region="FBiH", city="Breza"} 0
 # FBiH Grude
-cases_count{country="BA", region="FBiH", city="Grude"} 3
-recovered_count{country="BA", region="FBiH", city="Breza"} 0
+cases_count{country="BA", region="FBiH", city="Grude"} 4
+recovered_count{country="BA", region="FBiH", city="Grude"} 0
 deaths_count{country="BA", region="FBiH", city="Grude"} 0
 # FBiH Siroki Brijeg
 cases_count{country="BA", region="FBiH", city="Siroki Brijeg"} 7


### PR DESCRIPTION
https://www.klix.ba/vijesti/bih/jos-jedna-osoba-iz-gruda-pozitivna-na-koronavirus-broj-zarazenih-u-bih-sada-je-192/200327029