### PR TITLE
Novi slucajevi u Konjicu

### DIFF
--- a/metrics/current
+++ b/metrics/current
@@ -71,7 +71,7 @@ cases_count{country="BA", region="FBiH", city="Mostar"} 9
 recovered_count{country="BA", region="FBiH", city="Mostar"} 0
 deaths_count{country="BA", region="FBiH", city="Mostar"} 0
 # FBiH Konjic
-cases_count{country="BA", region="FBiH", city="Konjic"} 17
+cases_count{country="BA", region="FBiH", city="Konjic"} 21
 recovered_count{country="BA", region="FBiH", city="Konjic"} 0
 deaths_count{country="BA", region="FBiH", city="Konjic"} 0
 # FBiH Gorazde


### PR DESCRIPTION
https://www.klix.ba/vijesti/bih/nova-cetiri-slucaja-koronavirusa-u-konjicu-broj-zarazenih-u-ovom-gradu-popeo-se-na-21/200327058