### PR TITLE
2 osobe u Širokom

### DIFF
--- a/metrics/current
+++ b/metrics/current
@@ -131,7 +131,7 @@ cases_count{country="BA", region="FBiH", city="Grude"} 4
 recovered_count{country="BA", region="FBiH", city="Grude"} 0
 deaths_count{country="BA", region="FBiH", city="Grude"} 0
 # FBiH Siroki Brijeg
-cases_count{country="BA", region="FBiH", city="Siroki Brijeg"} 7
+cases_count{country="BA", region="FBiH", city="Siroki Brijeg"} 9
 recovered_count{country="BA", region="FBiH", city="Siroki Brijeg"} 0
 deaths_count{country="BA", region="FBiH", city="Siroki Brijeg"} 0
 # FBiH Citluk


### PR DESCRIPTION
https://www.klix.ba/vijesti/bih/jos-dvije-osobe-zarazene-koronavirusom-u-sirokom-brijegu-ukupno-232-u-bih/200327202